### PR TITLE
chore: Prettier & ESLint 통합 설정 + VSCode 자동 포맷 적용

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,5 +1,5 @@
 {
-  "extends": ["airbnb", "airbnb-typescript", "airbnb/hooks"],
+  "extends": ["airbnb", "airbnb-typescript", "airbnb/hooks", "plugin:prettier/recommended"],
   "env": {
     "browser": true,
     "es2021": true

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,27 @@
+# 기본적으로 제외해야 할 폴더
+node_modules
+.next
+out
+dist
+build
+coverage
+
+# 환경설정, 시스템 파일
+package-lock.json
+pnpm-lock.yaml
+yarn.lock
+
+# 이미지, 폰트, 기타 리소스
+*.png
+*.jpg
+*.jpeg
+*.gif
+*.svg
+*.ico
+*.woff
+*.woff2
+*.ttf
+*.eot
+
+# 기타
+public

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,10 @@
+{
+  "singleQuote": true,
+  "semi": true,
+  "tabWidth": 2,
+  "useTabs": false,
+  "trailingComma": "all",
+  "printWidth": 100,
+  "bracketSpacing": true,
+  "arrowParens": "always"
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,9 @@
+{
+  "editor.formatOnSave": true, // 저장 시 자동 포맷
+  "editor.defaultFormatter": "esbenp.prettier-vscode", // Prettier를 기본 포맷터로 지정
+  "editor.codeActionsOnSave": {
+    "source.fixAll.eslint": "always" // ESLint 자동 고치기 실행
+  },
+  "prettier.singleQuote": true, // ' 사용
+  "prettier.semi": true // 세미콜론 붙이기
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -28,6 +28,7 @@
         "eslint-plugin-react": "^7.33.2",
         "eslint-plugin-react-hooks": "^4.6.2",
         "globals": "^16.3.0",
+        "prettier": "^3.6.2",
         "tailwindcss": "^4",
         "typescript": "^5.4.5",
         "typescript-eslint": "^8.35.1"
@@ -4897,6 +4898,22 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/prettier": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.6.2.tgz",
+      "integrity": "sha512-I7AIg5boAr5R0FFtJ6rCfD+LFsWHp81dolrFD8S79U9tb8Az2nGrJncnMSnys+bpQJfRUzqs9hnA81OAA3hCuQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "prettier": "bin/prettier.cjs"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
       }
     },
     "node_modules/prop-types": {

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "eslint-plugin-react": "^7.33.2",
     "eslint-plugin-react-hooks": "^4.6.2",
     "globals": "^16.3.0",
+    "prettier": "^3.6.2",
     "tailwindcss": "^4",
     "typescript": "^5.4.5",
     "typescript-eslint": "^8.35.1"

--- a/src/app/test.tsx
+++ b/src/app/test.tsx
@@ -1,11 +1,11 @@
-import React from "react"; // 큰따옴표 위반
+import React from 'react'; // 큰따옴표 위반
 
-var count = 0; // var 사용 금지
+const count = 0; // var 사용 금지
 
 function Example() {
-  console.log("테스트"); // 콘솔 금지
+  console.log('테스트'); // 콘솔 금지
 
-  const msg = "Hello " + "World"; // 템플릿 리터럴 권장
+  const msg = 'Hello ' + 'World'; // 템플릿 리터럴 권장
 
   return <div>{msg}</div>;
 }


### PR DESCRIPTION
## 📑 연관 이슈
- 해당 PR은 초기 세팅이라 별도 이슈 없음

## 🛠️ 작업 내용
- Prettier 기본 스타일 통일 적용
- VSCode 저장 시 자동 포맷 적용
- `.prettierignore`로 필요 없는 파일 제외


## 👀 리뷰 요청사항
- Prettier, ESLint 옵션은 팀 협의로 추가 조정 가능
