### PR TITLE
fix: components.json utils 경로 파일명 수정(shadcnUtils)

### DIFF
--- a/components.json
+++ b/components.json
@@ -12,7 +12,7 @@
   },
   "aliases": {
     "components": "@/shared",
-    "utils": "@/shared/lib/utils",
+    "utils": "@/shared/lib/shadcnUtils",
     "ui": "@/shared/ui",
     "lib": "@/shared/lib",
     "hooks": "@/hooks"


### PR DESCRIPTION
## 📑 연관 이슈
- close: #34 

## 🛠️ 작업 내용
- components.json 에서 utils 항목의 경로 중 파일명 수정 (utils -> shadcnUtils)
- shadcn 컴포넌트 설치시 기본 셋팅 경로 잘못 지정되어있어 변경합니다.

## 👀 리뷰 요청사항