### PR TITLE
fix: Suspense로 useSearchParams 사용 컴포넌트 감싸 CSR fallback 현상 방지

### DIFF
--- a/src/app/auth/kakao/page.tsx
+++ b/src/app/auth/kakao/page.tsx
@@ -1,5 +1,8 @@
 import AuthKakao from '@/views/auth-kakao/AuthKakao';
+import { Suspense } from 'react';
 
 export default function KakaoCallbackPage() {
-  return <AuthKakao />;
+  <Suspense fallback={<div>Loading...</div>}>
+    return <AuthKakao />;
+  </Suspense>;
 }


### PR DESCRIPTION
## 📑 연관 이슈

- close: #75 

## 🛠️ 작업 내용

- Suspense 없이 useSearchParams 사용 시 전체 페이지가 CSR로 전환되어 초기 화면이 비어 보이는 문제 해결

## 👀 리뷰 요청사항

- 
