### PR TITLE
Feat/#85 커스텀 디자인 지정

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -64,10 +64,8 @@
   --color-primary-080: #0b0e44;
   --color-primary-090: #03052f;
 
-  /* sub_gradient */
-  --color-sub-gradient-005: #e2b9ff;
-  --color-sub-gradient-010: #da8afc;
-  --color-sub-gradient: linear-gradient(90deg, #431be4 0%, #fd98ff 100%);
+  --color-sub-gradient-left: #431be4;
+  --color-sub-gradient-right: #fd98ff;
 
   --color-danger: #f1351c;
 
@@ -218,6 +216,10 @@
 
   body {
     @apply bg-background text-foreground;
+  }
+
+  .sub-gradient {
+    @apply bg-gradient-to-r from-sub-gradient-left via-sub-gradient-right;
   }
 
   a {

--- a/src/views/test-page/TestPage.tsx
+++ b/src/views/test-page/TestPage.tsx
@@ -1,5 +1,9 @@
 'use client';
 
 export function TestPage() {
-  return <div>This Page is test Page.</div>;
+  return (
+    <div className="text-transparent bg-clip-text sub-gradient text-3xl font-bold">
+      This Page is test Page.
+    </div>
+  );
 }


### PR DESCRIPTION
## 📑 연관 이슈
- close: #85 
- PR: #86 

## 🛠️ 작업 내용
- **이전 globals.css 내용 복원**
  - 다크모드 관련 내용을 삭제했더니 shadcn 기존 스타일링으로 인해 깨지는 현상발생
- **sub-gradient 클래스 재지정**
  - `--color-sub-gradient`로만 지정해서는 실제 컴포넌트에 색이 안들어가는 문제발생
  - `@apply ` 로 테일윈트 클래스 사용하여 배경에 그라디언트 적용 클래스 생성
  - 사용 예시
    ```html
    // 글자 그라디언트
    <div className="text-transparent bg-clip-text sub-gradient">
      This Page is test Page.
    </div>

    // 배경 그라이언트
    <div className="sub-gradient">This Page is test Page.</div>
    ```

## 👀 리뷰 요청사항

- 
