### PR TITLE
feat: 유저 정보 수정 API 작성

### DIFF
--- a/src/entities/user/model/hooks/useUserStore.ts
+++ b/src/entities/user/model/hooks/useUserStore.ts
@@ -13,6 +13,8 @@ const useUserStore = create<UserState>()(
       isHydrated: false,
       logIn: (user: User) => set({ user, isLoggedIn: true }),
       logOut: () => set({ user: null, isLoggedIn: false, accessToken: '' }),
+      updateProfile: (partial) =>
+        set((state) => (state.user ? { user: { ...state.user, ...partial } } : state)),
       setAccessToken: (token: string) => set({ accessToken: token }),
       clearAccessToken: () => set({ accessToken: '' }),
       setHydrated: (value: boolean) => set({ isHydrated: value }),

--- a/src/entities/user/model/types.ts
+++ b/src/entities/user/model/types.ts
@@ -2,7 +2,7 @@ export interface User {
   email: string;
   nickname: string;
   profileImgUrl: string;
-  interest: string[];
+  interests: string[];
   memberId: number;
   accessToken: string;
 }
@@ -10,12 +10,13 @@ export interface User {
 export interface UserState {
   user: User | null;
   isLoggedIn: boolean;
+  accessToken: string;
+  isHydrated: boolean;
   logIn: (user: User) => void;
   logOut: () => void;
-  accessToken: string;
+  updateProfile: (partial: Partial<User>) => void;
   setAccessToken: (token: string) => void;
   clearAccessToken: () => void;
-  isHydrated: boolean;
   setHydrated: (value: boolean) => void;
 }
 

--- a/src/features/edit-user-profile/api/patchUserProfile.ts
+++ b/src/features/edit-user-profile/api/patchUserProfile.ts
@@ -1,0 +1,11 @@
+import { patchApi } from '@/shared/api/axiosApis';
+import UpdatedUserProfile from '../model/types';
+
+export default async function patchUserProfile(
+  userProfile: UpdatedUserProfile,
+): Promise<UpdatedUserProfile | null> {
+  const headers = {
+    'Content-Type': 'application/json',
+  };
+  return patchApi<UpdatedUserProfile>(`/api/v1/users/edit-profile`, userProfile, headers);
+}

--- a/src/features/edit-user-profile/model/hooks/usePatchUserProfileMutation.ts
+++ b/src/features/edit-user-profile/model/hooks/usePatchUserProfileMutation.ts
@@ -1,0 +1,18 @@
+import { useMutation, UseMutationResult } from '@tanstack/react-query';
+import patchUserProfile from '../../api/patchUserProfile';
+import { useUserStore } from '@/entities/user';
+import UpdatedUserProfile from '../types';
+export default function usePatchUserProfileMutation(): UseMutationResult<
+  UpdatedUserProfile | null,
+  Error,
+  UpdatedUserProfile,
+  unknown
+> {
+  const { updateProfile } = useUserStore((state) => state);
+  return useMutation({
+    mutationFn: (userProfile: UpdatedUserProfile) => patchUserProfile(userProfile),
+    onSuccess: (data) => {
+      if (data) updateProfile(data);
+    },
+  });
+}

--- a/src/features/edit-user-profile/model/types.ts
+++ b/src/features/edit-user-profile/model/types.ts
@@ -1,0 +1,3 @@
+import { User } from '@/entities/user';
+export default interface UpdatedUserProfile
+  extends Partial<Pick<User, 'nickname' | 'profileImgUrl' | 'interests'>> {}


### PR DESCRIPTION
## 📑 연관 이슈

- close: #105 

## 🛠️ 작업 내용

- 유저 정보 수정 API 작성
- UserState 속성 중 interest->interests로 변경
- useUserStore에 프로필 업데이트 액션 추가

## 👀 리뷰 요청사항

- 인터페이스명과 정의 쪽 살펴봐 주시면 감사하겠습니다.... 적절한지 궁금합니다
- 아직 백엔드에서 유저 정보 수정 API가 개발되지 않아서 추후 수정해야 할 수도 있을 것 같습니다!!
