### PR TITLE
fix: 로그아웃 시 블러 효과 즉시 반영 안되는 문제 수정

### DIFF
--- a/src/views/home/HomePage.tsx
+++ b/src/views/home/HomePage.tsx
@@ -3,23 +3,10 @@
 import { NewMeetingCardArea } from '@/entities/homeMeetingCard/index';
 import { Button } from '@/shared';
 import Link from 'next/link';
-
-import { useEffect, useState } from 'react';
+import { useUserStore } from '@/entities/user';
 
 export default function HomePage() {
-  const [isLoggedIn, setIsLoggedIn] = useState(true);
-
-  useEffect(() => {
-    try {
-      const stored = localStorage.getItem('user-storage');
-      if (stored) {
-        const parsed = JSON.parse(stored).state;
-        setIsLoggedIn(parsed.isLoggedIn);
-      }
-    } catch (error) {
-      throw new Error('Failed to parse user storage data');
-    }
-  }, []);
+  const isLoggedIn = useUserStore((state) => state.isLoggedIn);
 
   return (
     <main className="flex items-center justify-center flex-col gap-4 py-[40px]">


### PR DESCRIPTION
## 📑 연관 이슈

- close: #[issue number]

## 🛠️ 작업 내용

- 로그아웃 직후 블러 효과가 적용되지 않는 문제 수정
- 기존 `localStorage` 기반 로그인 상태 확인 → `zustand` 전역 상태 직접 구독 방식으로 변경
- `isLoggedIn` 값이 즉시 반영되어 블러 효과가 자연스럽게 처리되도록 개선
## 👀 리뷰 요청사항

- 
