### PR TITLE
fix: CarouselNext 버튼 비활성화 시 카드에 클릭 이벤트 전파되는 현상 차단

### DIFF
--- a/src/entities/homeMeetingCard/ui/newMeetingCardArea.tsx
+++ b/src/entities/homeMeetingCard/ui/newMeetingCardArea.tsx
@@ -13,7 +13,10 @@ export default function NewMeetingCardArea() {
       opts={{ loop: false, align: 'start', containScroll: 'trimSnaps' }}
       orientation="horizontal"
     >
-      <CarouselPrevious className="absolute -left-6 top-1/2 -translate-y-1/2 z-10 transition-shadow duration-300 hover:shadow-md" />
+      <CarouselPrevious
+        className="absolute -left-6 top-1/2 -translate-y-1/2 z-10 transition-shadow duration-300 hover:shadow-md"
+        style={{ pointerEvents: 'auto' }}
+      />
 
       <CarouselContent className="flex gap-[30px] ">
         {[1, 2, 3, 4, 5, 6, 7, 8, 9, 10].map((i) => (
@@ -25,7 +28,10 @@ export default function NewMeetingCardArea() {
         ))}
       </CarouselContent>
 
-      <CarouselNext className="absolute -right-6 top-1/2 -translate-y-1/2 z-10 transition-shadow duration-300 hover:shadow-md" />
+      <CarouselNext
+        className="absolute -right-6 top-1/2 -translate-y-1/2 z-10 transition-shadow duration-300 hover:shadow-md"
+        style={{ pointerEvents: 'auto' }}
+      />
     </Carousel>
   );
 }


### PR DESCRIPTION
## 📑 연관 이슈

- close: #128 

## 🛠️ 작업 내용

- CarouselNext 버튼이 비활성화된 상태에서 클릭 시, 하위 요소인 카드로 이벤트가 전파되는 문제 발생
- 이는 버튼이 `disabled` 상태가 되면 브라우저에서 자동으로 `pointer-events: none`을 적용하기 때문에 발생한 현상
- 해당 문제를 해결하기 위해 `style={{ pointerEvents: 'auto' }}`를 명시적으로 추가하여 이벤트 전파를 차단
- Tailwind에서 `disabled:pointer-events-auto`를 시도할 수 있으나, 실제 브라우저 동작에선 우선순위 문제로 제대로 적용되지 않아 `style`로 강제 오버라이딩
- 디자인 상 버튼이 카드 위에 겹쳐 있는 구조를 유지하면서도 UX 문제 없이 클릭 방지 처리됨

## 👀 리뷰 요청사항

- 
