### PR TITLE
Bugfix/#174 로그아웃시 내가 좋아할 모임 & 위시리스트가 보이는 이슈 해결

### DIFF
--- a/src/entities/homeMeetingCard/index.ts
+++ b/src/entities/homeMeetingCard/index.ts
@@ -2,3 +2,4 @@ export { default as FavoriteMeetingCardArea } from './ui/favoriteMeetingCardArea
 export { default as NewMeetingCardArea } from './ui/newMeetingCardArea';
 export { default as PopularMeetingCardArea } from './ui/popularMeetingCardArea';
 export { default as WishlistCardArea } from './ui/wishlistCardArea';
+export { default as DummyCardArea } from './ui/dummyCardArea';

--- a/src/entities/homeMeetingCard/model/homeMeetingCard.keys.ts
+++ b/src/entities/homeMeetingCard/model/homeMeetingCard.keys.ts
@@ -9,8 +9,8 @@ const homeMeetingCardKeys = createQueryKeys('homeMeetingCard', {
     queryKey: ['new'],
     queryFn: () => getNewMeetings(),
   }),
-  wishlist: () => ({
-    queryKey: ['wishlist'],
+  wishlist: (userId?: number) => ({
+    queryKey: ['wishlist', userId],
     queryFn: () => getWishlistMeetings(),
   }),
   favorite: (interests: string[]) => ({

--- a/src/entities/homeMeetingCard/model/hooks/useWishlistQuery.ts
+++ b/src/entities/homeMeetingCard/model/hooks/useWishlistQuery.ts
@@ -1,7 +1,10 @@
 import { useQuery, UseQueryResult } from '@tanstack/react-query';
+import { useUserStore } from '@/entities/user';
 import homeMeetingCardKeys from '../homeMeetingCard.keys';
 import { HomeMeetingCard } from '../types';
 
 export default function useWishlistMeetingsQuery(): UseQueryResult<HomeMeetingCard[] | null> {
-  return useQuery(homeMeetingCardKeys.wishlist());
+  const userId = useUserStore((state) => state.user?.memberId);
+
+  return useQuery(homeMeetingCardKeys.wishlist(userId));
 }

--- a/src/entities/homeMeetingCard/ui/dummyCardArea.tsx
+++ b/src/entities/homeMeetingCard/ui/dummyCardArea.tsx
@@ -1,0 +1,67 @@
+'use client';
+
+import { DrinkType } from '@/shared';
+import {
+  Carousel,
+  CarouselContent,
+  CarouselItem,
+  CarouselNext,
+  CarouselPrevious,
+} from '@/shared/ui';
+import { FindMeetingCard } from '@/widgets/index';
+
+type FindMeetingCardProps = Parameters<typeof FindMeetingCard>[0];
+type MeetingInfo = FindMeetingCardProps['meetingInfo'];
+
+const BASE_DUMMY: MeetingInfo = {
+  meetingId: -1,
+  meetingAuthor: 'ToTasty',
+  meetingTitle: '샘플 테이스팅',
+  location: { sido: '서울특별시', address: '용산구 한강대로 405', detail: '샘플 장소' },
+  participationFee: 30000,
+  startAt: '2025-12-31T10:30:00',
+  joinEndAt: '2025-12-30T23:59:00',
+  maxParticipants: 10,
+  minParticipants: 3,
+  currentParticipants: 1,
+  tastingDrinkCount: 1,
+  isWished: false,
+  thumbnailUrl: '/assets/image/card-test-1.jpg',
+  status: 'open',
+  drinkType: DrinkType.wine,
+  isReviewed: false,
+  participation: [],
+};
+
+const DUMMY_LIST: MeetingInfo[] = Array.from({ length: 4 }, (_, i) => ({
+  ...BASE_DUMMY,
+  meetingId: -(i + 1),
+}));
+
+export default function DummyCardArea() {
+  return (
+    <Carousel
+      className="relative w-[1142px] overflow-visible"
+      opts={{ loop: false, align: 'start', containScroll: 'trimSnaps' }}
+      orientation="horizontal"
+    >
+      <CarouselPrevious
+        className="absolute -left-6 top-1/2 -translate-y-1/2 z-10 transition-shadow duration-300 hover:shadow-md"
+        style={{ pointerEvents: 'auto' }}
+      />
+
+      <CarouselContent className="flex gap-[30px] pointer-events-none" aria-hidden="true">
+        {DUMMY_LIST.map((card) => (
+          <CarouselItem key={card.meetingId} className="flex-shrink-0 basis-[263px]">
+            <FindMeetingCard meetingInfo={card} size="big" />
+          </CarouselItem>
+        ))}
+      </CarouselContent>
+
+      <CarouselNext
+        className="absolute -right-6 top-1/2 -translate-y-1/2 z-10 transition-shadow duration-300 hover:shadow-md"
+        style={{ pointerEvents: 'auto' }}
+      />
+    </Carousel>
+  );
+}

--- a/src/views/home/HomePage.tsx
+++ b/src/views/home/HomePage.tsx
@@ -5,6 +5,7 @@ import {
   NewMeetingCardArea,
   PopularMeetingCardArea,
   WishlistCardArea,
+  DummyCardArea,
 } from '@/entities/homeMeetingCard/index';
 import { Button } from '@/shared';
 import Link from 'next/link';
@@ -28,10 +29,10 @@ export default function HomePage() {
           className={`flex flex-col gap-4 mt-8 ${!isLoggedIn ? 'blur-sm pointer-events-none' : ''}`}
         >
           <h1 className="font-semibold text-xl ">내가 좋아할 모임</h1>
-          <FavoriteMeetingCardArea />
+          {isLoggedIn ? <FavoriteMeetingCardArea /> : <DummyCardArea />}
           <div>
             <h1 className="font-semibold text-xl pb-[20px]">위시리스트</h1>
-            <WishlistCardArea />
+            {isLoggedIn ? <WishlistCardArea /> : <DummyCardArea />}
           </div>
         </div>
       </div>


### PR DESCRIPTION
## 📑 연관 이슈

- close: #174 

## 🛠️ 작업 내용

- 홈 메인 비로그인 상태에서 ‘내가 좋아할 모임’/‘위시리스트’ 대신 **DummyCardArea** 렌더링
- ['wishlist', userId]로 캐시가 로그인 상태별로 분리됨 → 로그아웃/로그인 시 자동 재요청+화면 갱신.

## 👀 리뷰 요청사항

- 
