### PR TITLE
fix: 다중 관심사 반영 및 최신순 10개 노출

### DIFF
--- a/src/entities/homeMeetingCard/api/getFavoriteMeetings.ts
+++ b/src/entities/homeMeetingCard/api/getFavoriteMeetings.ts
@@ -2,12 +2,24 @@ import { getApi } from '@/shared';
 import { HomeMeetingCard } from '../model/types';
 
 export default async function getFavoriteMeetings(interests: string[]): Promise<HomeMeetingCard[]> {
-  if (!interests || interests.length === 0) return [];
+  if (!interests?.length) return [];
 
-  const interestParams = interests.map((type) => `drinkType=${type}`).join('&');
-  const res = await getApi<{ content: HomeMeetingCard[] }>(
-    `/api/v1/meetings?${interestParams}&page=1&size=10`,
+  const pages = await Promise.all(
+    interests.map((type) =>
+      getApi<{ content: HomeMeetingCard[] }>(`/api/v1/meetings?drinkType=${type}&page=1&size=10`),
+    ),
   );
 
-  return res ? res.content : [];
+  const merged = pages.flatMap((res) => res?.content ?? []);
+
+  const toTime = (m: HomeMeetingCard): number => {
+    const raw = m.startAt ?? m.joinEndAt;
+    if (!raw) return 0;
+    const timeMs = Date.parse(raw);
+    return Number.isFinite(timeMs) ? timeMs : 0;
+  };
+
+  merged.sort((a, b) => toTime(b) - toTime(a));
+
+  return merged.slice(0, 10);
 }


### PR DESCRIPTION
## 📑 연관 이슈

- close: #159 

## 🛠️ 작업 내용

- interests 배열 기반으로 병렬 요청(Promise.all) 수행 후 응답 content 병합
- 상위 10개만 노출되도록 slice(0, 10) 적용
- 기존에 첫 번째 관심사만 반영되던 문제 제거

## 👀 리뷰 요청사항

- 
