### PR TITLE
Feat/#198 상세페이지 하단 풋터 구현

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@lukemorales/query-key-factory": "^1.3.4",
+        "@radix-ui/react-alert-dialog": "^1.1.14",
         "@radix-ui/react-dialog": "^1.1.14",
         "@radix-ui/react-dropdown-menu": "^2.1.15",
         "@radix-ui/react-label": "^2.1.7",
@@ -2187,6 +2188,34 @@
       "resolved": "https://registry.npmjs.org/@radix-ui/primitive/-/primitive-1.1.2.tgz",
       "integrity": "sha512-XnbHrrprsNqZKQhStrSwgRUQzoCI1glLzdw79xiZPoofhGICeZRSQ3dIxAKH1gb3OHfNf4d6f+vAv3kil2eggA=="
     },
+    "node_modules/@radix-ui/react-alert-dialog": {
+      "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-alert-dialog/-/react-alert-dialog-1.1.14.tgz",
+      "integrity": "sha512-IOZfZ3nPvN6lXpJTBCunFQPRSvK8MDgSc1FB85xnIpUKOw9en0dJj8JmCAxV7BiZdtYlUpmrQjoTFkVYtdoWzQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.2",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-dialog": "1.1.14",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-slot": "1.2.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@radix-ui/react-arrow": {
       "version": "1.1.7",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-arrow/-/react-arrow-1.1.7.tgz",
@@ -2750,6 +2779,7 @@
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.3.tgz",
       "integrity": "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==",
+      "license": "MIT",
       "dependencies": {
         "@radix-ui/react-compose-refs": "1.1.2"
       },

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
   },
   "dependencies": {
     "@lukemorales/query-key-factory": "^1.3.4",
+    "@radix-ui/react-alert-dialog": "^1.1.14",
     "@radix-ui/react-dialog": "^1.1.14",
     "@radix-ui/react-dropdown-menu": "^2.1.15",
     "@radix-ui/react-label": "^2.1.7",

--- a/src/shared/ui/AlertDialog.tsx
+++ b/src/shared/ui/AlertDialog.tsx
@@ -1,0 +1,134 @@
+'use client';
+
+import * as AlertDialogPrimitive from '@radix-ui/react-alert-dialog';
+
+import { cn } from '@/shared/lib/shadcnUtils';
+import { buttonVariants } from '@/shared/ui/Button';
+
+function AlertDialog({ ...props }: React.ComponentProps<typeof AlertDialogPrimitive.Root>) {
+  return <AlertDialogPrimitive.Root data-slot="alert-dialog" {...props} />;
+}
+
+function AlertDialogTrigger({
+  ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Trigger>) {
+  return <AlertDialogPrimitive.Trigger data-slot="alert-dialog-trigger" {...props} />;
+}
+
+function AlertDialogPortal({ ...props }: React.ComponentProps<typeof AlertDialogPrimitive.Portal>) {
+  return <AlertDialogPrimitive.Portal data-slot="alert-dialog-portal" {...props} />;
+}
+
+function AlertDialogOverlay({
+  className,
+  ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Overlay>) {
+  return (
+    <AlertDialogPrimitive.Overlay
+      data-slot="alert-dialog-overlay"
+      className={cn(
+        'data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 fixed inset-0 z-50 bg-black/50',
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function AlertDialogContent({
+  className,
+  ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Content>) {
+  return (
+    <AlertDialogPortal>
+      <AlertDialogOverlay />
+      <AlertDialogPrimitive.Content
+        data-slot="alert-dialog-content"
+        className={cn(
+          'bg-background data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 fixed top-[50%] left-[50%] z-50 grid w-full max-w-[calc(100%-2rem)] translate-x-[-50%] translate-y-[-50%] gap-4 rounded-lg border p-6 shadow-lg duration-200 sm:max-w-lg',
+          className,
+        )}
+        {...props}
+      />
+    </AlertDialogPortal>
+  );
+}
+
+function AlertDialogHeader({ className, ...props }: React.ComponentProps<'div'>) {
+  return (
+    <div
+      data-slot="alert-dialog-header"
+      className={cn('flex flex-col gap-2 text-center sm:text-left', className)}
+      {...props}
+    />
+  );
+}
+
+function AlertDialogFooter({ className, ...props }: React.ComponentProps<'div'>) {
+  return (
+    <div
+      data-slot="alert-dialog-footer"
+      className={cn('flex flex-col-reverse gap-2 sm:flex-row sm:justify-end', className)}
+      {...props}
+    />
+  );
+}
+
+function AlertDialogTitle({
+  className,
+  ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Title>) {
+  return (
+    <AlertDialogPrimitive.Title
+      data-slot="alert-dialog-title"
+      className={cn('text-lg font-semibold', className)}
+      {...props}
+    />
+  );
+}
+
+function AlertDialogDescription({
+  className,
+  ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Description>) {
+  return (
+    <AlertDialogPrimitive.Description
+      data-slot="alert-dialog-description"
+      className={cn('text-muted-foreground text-sm', className)}
+      {...props}
+    />
+  );
+}
+
+function AlertDialogAction({
+  className,
+  ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Action>) {
+  return <AlertDialogPrimitive.Action className={cn(buttonVariants(), className)} {...props} />;
+}
+
+function AlertDialogCancel({
+  className,
+  ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Cancel>) {
+  return (
+    <AlertDialogPrimitive.Cancel
+      className={cn(buttonVariants({ variant: 'outline' }), className)}
+      {...props}
+    />
+  );
+}
+
+export {
+  AlertDialog,
+  AlertDialogPortal,
+  AlertDialogOverlay,
+  AlertDialogTrigger,
+  AlertDialogContent,
+  AlertDialogHeader,
+  AlertDialogFooter,
+  AlertDialogTitle,
+  AlertDialogDescription,
+  AlertDialogAction,
+  AlertDialogCancel,
+};

--- a/src/shared/ui/Button.tsx
+++ b/src/shared/ui/Button.tsx
@@ -48,6 +48,7 @@ function Button({
   variant,
   size,
   asChild = false,
+  disabled,
   ...props
 }: React.ComponentProps<'button'> &
   VariantProps<typeof buttonVariants> & {
@@ -58,7 +59,10 @@ function Button({
   return (
     <Comp
       data-slot="button"
-      className={cn(buttonVariants({ variant, size, className }))}
+      className={cn(buttonVariants({ variant, size, className }), {
+        'text-muted-foreground border-muted cursor-not-allowed': disabled,
+      })}
+      disabled={disabled}
       {...props}
     />
   );

--- a/src/shared/ui/index.ts
+++ b/src/shared/ui/index.ts
@@ -66,3 +66,5 @@ export { Command, CommandGroup, CommandItem, CommandList } from './Command';
 export { Tabs, TabsList, TabsTrigger, TabsContent } from './Tabs';
 export { Progress } from './Progress';
 export { Badge } from './Badge';
+
+export * from './AlertDialog';

--- a/src/views/meetings/detail/MeetingDetailPage.tsx
+++ b/src/views/meetings/detail/MeetingDetailPage.tsx
@@ -2,7 +2,7 @@
 
 import { useMeetingDetailQuery } from '@/entities/meetings';
 import { MeetingDetailInfo } from '@/entities/meetings/model/types';
-import { MeetingDetailHeader, ContentBox } from '@/widgets/detail-meeting';
+import { MeetingDetailHeader, MeetingDetailFooter, ContentBox } from '@/widgets/detail-meeting';
 
 export default function MeetingDetailPage({ meetingId }: { meetingId: number }) {
   const { data: meetingData, isLoading, error } = useMeetingDetailQuery(meetingId);
@@ -12,13 +12,20 @@ export default function MeetingDetailPage({ meetingId }: { meetingId: number }) 
   if (!meetingData) return <div>모임 정보를 불러오는 중입니다...</div>;
 
   return (
-    <main className="max-w-[1000px] mx-auto px-4 py-6">
+    <main className="max-w-[1000px] mx-auto py-8">
       <div className="mb-8">
         <MeetingDetailHeader {...(meetingData as MeetingDetailInfo)} />
       </div>
 
       <div className="space-y-4">
         <ContentBox title="모임 상세 설명" content={meetingData.content} />
+        <MeetingDetailFooter
+          meetingId={meetingData.meetingId}
+          currentParticipants={meetingData.currentParticipants}
+          maxParticipants={meetingData.maxParticipants}
+          participationFee={meetingData.participationFee}
+          status={meetingData.status}
+        />
       </div>
     </main>
   );

--- a/src/views/meetings/detail/MeetingDetailPage.tsx
+++ b/src/views/meetings/detail/MeetingDetailPage.tsx
@@ -1,15 +1,75 @@
 'use client';
 
-import { useMeetingDetailQuery } from '@/entities/meetings';
-import { MeetingDetailInfo } from '@/entities/meetings/model/types';
+import { useRouter } from 'next/navigation';
+import {
+  useMeetingDetailQuery,
+  // useJoinMeetingMutation,
+  // useCancelJoinMutation,
+  // useCancelMeetingMutation,
+} from '@/entities/meetings';
+import type { MeetingDetailInfo } from '@/entities/meetings/model/types';
 import { MeetingDetailHeader, MeetingDetailFooter, ContentBox } from '@/widgets/detail-meeting';
+import { Role } from '@/widgets/detail-meeting/model/types';
+import { useUserStore } from '@/entities/user';
 
 export default function MeetingDetailPage({ meetingId }: { meetingId: number }) {
+  const router = useRouter();
   const { data: meetingData, isLoading, error } = useMeetingDetailQuery(meetingId);
+  const isLoggedIn = useUserStore((s) => s.isLoggedIn);
+  const user = useUserStore((s) => s.user);
 
   if (isLoading) return <div>로딩 중...</div>;
   if (error) return <div>오류: {(error as Error).message}</div>;
   if (!meetingData) return <div>모임 정보를 불러오는 중입니다...</div>;
+
+  const displayName = user?.nickname ?? '';
+  const isHost = Boolean(
+    isLoggedIn && displayName && meetingData && displayName === meetingData.meetingAuthor,
+  );
+
+  let role: Role;
+  if (isHost) role = Role.host;
+  else if (isLoggedIn) role = Role.member;
+  else role = Role.guest;
+
+  const currentUrl = typeof window !== 'undefined' ? window.location.href : '';
+  // --- mutations (프로젝트 훅으로 교체) ---
+  // const joinMutation = useJoinMeetingMutation();
+  // const cancelJoinMutation = useCancelJoinMutation();
+  // const cancelMeetingMutation = useCancelMeetingMutation();
+
+  const handlers = {
+    onLogin: () => {
+      router.push(`/login?redirect=/meetings/${meetingId}`);
+    },
+    onJoin: () => {
+      // joinMutation.mutate({ meetingId });
+      console.log(`[${meetingId}] 참여하기 클릭됨`);
+    },
+    onCancelJoin: () => {
+      // cancelJoinMutation.mutate({ meetingId });
+      console.log(`[${meetingId}] 참여취소 클릭됨`);
+    },
+    onWriteReview: () => {
+      // router.push(`/meetings/${meetingId}/review`);
+      console.log(`[${meetingId}] 리뷰 작성 이동`);
+    },
+    onShare: () => {
+      if (navigator.share) {
+        navigator.share({ title: 'To tasty', url: currentUrl }).catch(() => {});
+      } else {
+        navigator.clipboard.writeText(currentUrl);
+        alert('링크가 복사되었습니다.');
+      }
+    },
+    onCancelMeeting: () => {
+      // if (confirm('정말로 모임을 취소하시겠습니까?')) {
+      // cancelMeetingMutation.mutate({ meetingId });
+      console.log(`[${meetingId}] 모임 취소 클릭됨`);
+      // }
+    },
+    onNoop: () => {},
+  };
 
   return (
     <main className="max-w-[1000px] mx-auto py-8">
@@ -19,12 +79,12 @@ export default function MeetingDetailPage({ meetingId }: { meetingId: number }) 
 
       <div className="space-y-4">
         <ContentBox title="모임 상세 설명" content={meetingData.content} />
+
         <MeetingDetailFooter
-          meetingId={meetingData.meetingId}
-          currentParticipants={meetingData.currentParticipants}
-          maxParticipants={meetingData.maxParticipants}
-          participationFee={meetingData.participationFee}
-          status={meetingData.status}
+          meeting={meetingData as MeetingDetailInfo}
+          role={role}
+          isHost={isHost}
+          handlers={handlers}
         />
       </div>
     </main>

--- a/src/views/meetings/detail/MeetingDetailPage.tsx
+++ b/src/views/meetings/detail/MeetingDetailPage.tsx
@@ -11,12 +11,14 @@ import type { MeetingDetailInfo } from '@/entities/meetings/model/types';
 import { MeetingDetailHeader, MeetingDetailFooter, ContentBox } from '@/widgets/detail-meeting';
 import { Role } from '@/widgets/detail-meeting/model/types';
 import { useUserStore } from '@/entities/user';
+import { useConfirm } from '@/widgets/detail-meeting/model/hook/useConfirm';
 
 export default function MeetingDetailPage({ meetingId }: { meetingId: number }) {
   const router = useRouter();
   const { data: meetingData, isLoading, error } = useMeetingDetailQuery(meetingId);
   const isLoggedIn = useUserStore((s) => s.isLoggedIn);
   const user = useUserStore((s) => s.user);
+  const { confirm, ConfirmDialog } = useConfirm();
 
   if (isLoading) return <div>로딩 중...</div>;
   if (error) return <div>오류: {(error as Error).message}</div>;
@@ -62,11 +64,16 @@ export default function MeetingDetailPage({ meetingId }: { meetingId: number }) 
         alert('링크가 복사되었습니다.');
       }
     },
-    onCancelMeeting: () => {
-      // if (confirm('정말로 모임을 취소하시겠습니까?')) {
+    onCancelMeeting: async () => {
+      const ok = await confirm({
+        title: '모임 취소',
+        description: '정말로 모임을 취소하시겠습니까?',
+        confirmText: '네, 취소합니다',
+        cancelText: '아니요',
+        destructive: true,
+      });
+      if (!ok) return;
       // cancelMeetingMutation.mutate({ meetingId });
-      console.log(`[${meetingId}] 모임 취소 클릭됨`);
-      // }
     },
     onNoop: () => {},
   };
@@ -87,6 +94,8 @@ export default function MeetingDetailPage({ meetingId }: { meetingId: number }) 
           handlers={handlers}
         />
       </div>
+
+      <ConfirmDialog />
     </main>
   );
 }

--- a/src/widgets/detail-meeting/ContentBox.tsx
+++ b/src/widgets/detail-meeting/ContentBox.tsx
@@ -4,7 +4,7 @@ export default function ContentBox({ title, content }: ContentBoxProps) {
   return (
     <div className="space-y-2">
       <h3 className="text-lg font-semibold mb-2">{title}</h3>
-      <div className="border-t-1 border-b-1 border-primary/30 p-4 rounded-3xl min-h-[300px]">
+      <div className="border-t-1 border-b-1 border-primary/30 p-4 rounded-3xl min-h-[300px] whitespace-break-spaces">
         {content}
       </div>
     </div>

--- a/src/widgets/detail-meeting/MeetingDetailFooter.tsx
+++ b/src/widgets/detail-meeting/MeetingDetailFooter.tsx
@@ -1,0 +1,120 @@
+'use client';
+
+import { useState, useEffect, useRef } from 'react';
+import { Button } from '@/shared/ui';
+import { useUserStore } from '@/entities/user';
+
+export default function MeetingDetailFooter({
+  meetingId,
+  currentParticipants,
+  maxParticipants,
+  participationFee,
+  status,
+}: {
+  meetingId: number;
+  currentParticipants: number;
+  maxParticipants: number;
+  participationFee: number;
+  status: string;
+}) {
+  const { isLoggedIn } = useUserStore((state) => state);
+  const [isMobile, setIsMobile] = useState(false);
+  const [isFixed, setIsFixed] = useState(true);
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const checkMobile = () => {
+      setIsMobile(window.innerWidth < 768);
+    };
+
+    const handleScroll = () => {
+      if (isMobile) {
+        setIsFixed(false);
+        return;
+      }
+
+      const windowHeight = window.innerHeight;
+      const documentHeight = document.documentElement.scrollHeight;
+      const scrollTop = window.scrollY;
+
+      const isNearBottom = scrollTop + windowHeight >= documentHeight - 80;
+      setIsFixed(!isNearBottom);
+    };
+
+    checkMobile();
+    handleScroll();
+
+    window.addEventListener('resize', checkMobile);
+    window.addEventListener('scroll', handleScroll);
+
+    return () => {
+      window.removeEventListener('resize', checkMobile);
+      window.removeEventListener('scroll', handleScroll);
+    };
+  }, [isMobile]);
+
+  const isFull = currentParticipants >= maxParticipants;
+  const isClosed = status === 'closed' || status === 'cancelled';
+
+  const isJoinDisabled = isFull || isClosed;
+
+  const handleJoin = () => {
+    if (!isLoggedIn) {
+      alert('로그인이 필요한 기능입니다.');
+      return;
+    }
+
+    console.log(`모임 ${meetingId} 참가 신청`);
+  };
+
+  let containerClass = 'relative mt-20';
+  if (isMobile) {
+    containerClass = 'relative mt-8';
+  } else if (isFixed) {
+    containerClass = 'fixed bottom-0 left-0';
+  }
+
+  let buttonLabel = '참여하기';
+  if (isFull) {
+    buttonLabel = '모집 마감';
+  } else if (isClosed) {
+    buttonLabel = '모임 종료';
+  }
+
+  return (
+    <>
+      {!isMobile && isFixed && <div className="h-32" />}
+
+      <div
+        ref={containerRef}
+        className={`border-t border-muted bg-background z-10 w-full py-3 px-4 ${containerClass}`}
+      >
+        <div className="max-w-[1000px] m-auto flex items-center justify-between">
+          <div className="flex flex-col">
+            <span className="font-bold text-lg">
+              참가비 : {participationFee === 0 ? '무료' : `${participationFee.toLocaleString()}원`}
+            </span>
+            <span className="text-xs text-muted-foreground">
+              모두 함께 To tasty! 한 모금으로 이어지는 나만의 취향 찾기
+            </span>
+          </div>
+
+          <div className="flex items-center gap-2">
+            <span className="text-sm hidden sm:block mr-2">
+              {currentParticipants}/{maxParticipants}명 참여 중
+            </span>
+
+            <Button
+              variant={isJoinDisabled ? 'outline' : 'default'}
+              disabled={isJoinDisabled}
+              onClick={handleJoin}
+              className={`px-6 py-5 min-w-[120px] ${isJoinDisabled ? 'text-muted-foreground' : 'text-white'}`}
+            >
+              {buttonLabel}
+            </Button>
+          </div>
+        </div>
+      </div>
+    </>
+  );
+}

--- a/src/widgets/detail-meeting/MeetingDetailFooter.tsx
+++ b/src/widgets/detail-meeting/MeetingDetailFooter.tsx
@@ -1,85 +1,48 @@
 'use client';
 
-import { useState, useEffect, useRef } from 'react';
-import { Button } from '@/shared/ui';
+import { useMemo, useRef } from 'react';
 import { useUserStore } from '@/entities/user';
+import { useStickyFooter } from './model/hook/useStickyFooter';
+import { ActionButtons, FooterText, ParticipantsText } from './ui';
+import { MeetingFooterProps, FooterCtx, Role, MeetingStatus } from './model/types';
 
-export default function MeetingDetailFooter({
-  meetingId,
-  currentParticipants,
-  maxParticipants,
-  participationFee,
-  status,
-}: {
-  meetingId: number;
-  currentParticipants: number;
-  maxParticipants: number;
-  participationFee: number;
-  status: string;
-}) {
-  const { isLoggedIn } = useUserStore((state) => state);
-  const [isMobile, setIsMobile] = useState(false);
-  const [isFixed, setIsFixed] = useState(true);
+const cx = (...v: (string | false | undefined)[]) => v.filter(Boolean).join(' ');
+
+export default function MeetingDetailFooter(props: MeetingFooterProps) {
+  const { meeting, role: roleProp, isHost, handlers } = props;
+  const { isLoggedIn } = useUserStore((s) => s);
+
+  const { isMobile, isFixed } = useStickyFooter();
   const containerRef = useRef<HTMLDivElement>(null);
 
-  useEffect(() => {
-    const checkMobile = () => {
-      setIsMobile(window.innerWidth < 768);
-    };
+  const role: Role = isHost ? Role.host : (roleProp ?? (isLoggedIn ? Role.member : Role.guest));
 
-    const handleScroll = () => {
-      if (isMobile) {
-        setIsFixed(false);
-        return;
-      }
+  const ctx: FooterCtx = useMemo(
+    () => ({
+      role,
+      status: meeting.status as MeetingStatus,
+      current: meeting.currentParticipants,
+      max: meeting.maxParticipants,
+      fee: meeting.participationFee,
+      isParticipated: meeting.isParticipated,
+      isReviewed: meeting.isReviewed,
+    }),
+    [
+      role,
+      meeting.status,
+      meeting.currentParticipants,
+      meeting.maxParticipants,
+      meeting.participationFee,
+      meeting.isParticipated,
+      meeting.isReviewed,
+    ],
+  );
 
-      const windowHeight = window.innerHeight;
-      const documentHeight = document.documentElement.scrollHeight;
-      const scrollTop = window.scrollY;
-
-      const isNearBottom = scrollTop + windowHeight >= documentHeight - 80;
-      setIsFixed(!isNearBottom);
-    };
-
-    checkMobile();
-    handleScroll();
-
-    window.addEventListener('resize', checkMobile);
-    window.addEventListener('scroll', handleScroll);
-
-    return () => {
-      window.removeEventListener('resize', checkMobile);
-      window.removeEventListener('scroll', handleScroll);
-    };
-  }, [isMobile]);
-
-  const isFull = currentParticipants >= maxParticipants;
-  const isClosed = status === 'closed' || status === 'cancelled';
-
-  const isJoinDisabled = isFull || isClosed;
-
-  const handleJoin = () => {
-    if (!isLoggedIn) {
-      alert('로그인이 필요한 기능입니다.');
-      return;
-    }
-
-    console.log(`모임 ${meetingId} 참가 신청`);
-  };
-
-  let containerClass = 'relative mt-20';
-  if (isMobile) {
-    containerClass = 'relative mt-8';
-  } else if (isFixed) {
-    containerClass = 'fixed bottom-0 left-0';
-  }
-
-  let buttonLabel = '참여하기';
-  if (isFull) {
-    buttonLabel = '모집 마감';
-  } else if (isClosed) {
-    buttonLabel = '모임 종료';
-  }
+  const containerClass = isMobile
+    ? 'relative mt-8'
+    : isFixed
+      ? 'fixed bottom-0 left-0'
+      : 'relative mt-20';
 
   return (
     <>
@@ -87,31 +50,14 @@ export default function MeetingDetailFooter({
 
       <div
         ref={containerRef}
-        className={`border-t border-muted bg-background z-10 w-full py-3 px-4 ${containerClass}`}
+        className={cx('border-t border-muted bg-background z-10 w-full py-3 px-4', containerClass)}
       >
         <div className="max-w-[1000px] m-auto flex items-center justify-between">
-          <div className="flex flex-col">
-            <span className="font-bold text-lg">
-              참가비 : {participationFee === 0 ? '무료' : `${participationFee.toLocaleString()}원`}
-            </span>
-            <span className="text-xs text-muted-foreground">
-              모두 함께 To tasty! 한 모금으로 이어지는 나만의 취향 찾기
-            </span>
-          </div>
+          <FooterText fee={meeting.participationFee} />
 
           <div className="flex items-center gap-2">
-            <span className="text-sm hidden sm:block mr-2">
-              {currentParticipants}/{maxParticipants}명 참여 중
-            </span>
-
-            <Button
-              variant={isJoinDisabled ? 'outline' : 'default'}
-              disabled={isJoinDisabled}
-              onClick={handleJoin}
-              className={`px-6 py-5 min-w-[120px] ${isJoinDisabled ? 'text-muted-foreground' : 'text-white'}`}
-            >
-              {buttonLabel}
-            </Button>
+            <ParticipantsText current={meeting.currentParticipants} max={meeting.maxParticipants} />
+            <ActionButtons ctx={ctx} handlers={handlers} />
           </div>
         </div>
       </div>

--- a/src/widgets/detail-meeting/MeetingDetailFooter.tsx
+++ b/src/widgets/detail-meeting/MeetingDetailFooter.tsx
@@ -38,11 +38,9 @@ export default function MeetingDetailFooter(props: MeetingFooterProps) {
     ],
   );
 
-  const containerClass = isMobile
-    ? 'relative mt-8'
-    : isFixed
-      ? 'fixed bottom-0 left-0'
-      : 'relative mt-20';
+  let containerClass = 'relative mt-20';
+  if (isMobile) containerClass = 'relative mt-8';
+  else if (isFixed) containerClass = 'fixed bottom-0 left-0';
 
   return (
     <>

--- a/src/widgets/detail-meeting/index.ts
+++ b/src/widgets/detail-meeting/index.ts
@@ -1,2 +1,3 @@
 export { default as MeetingDetailHeader } from './MeetingDetailHeader';
+export { default as MeetingDetailFooter } from './MeetingDetailFooter';
 export { default as ContentBox } from './ContentBox';

--- a/src/widgets/detail-meeting/model/actions.ts
+++ b/src/widgets/detail-meeting/model/actions.ts
@@ -1,0 +1,74 @@
+import { ActionDef, ActionId, ButtonVariant, FooterCtx, MeetingStatus, Role } from './types';
+
+export const ACTIONS: ActionDef[] = [
+  {
+    id: ActionId.Login,
+    label: '로그인하기',
+    visibleIf: (c: FooterCtx) => c.role === Role.guest && c.status === MeetingStatus.open,
+    variant: ButtonVariant.Default,
+    handlerKey: 'onLogin',
+  },
+  {
+    id: ActionId.DisabledClosed,
+    label: '모임 종료',
+    visibleIf: (c: FooterCtx) =>
+      c.status === MeetingStatus.closed || c.status === MeetingStatus.cancelled,
+    variant: ButtonVariant.Outline,
+    handlerKey: 'onNoop',
+    disabled: () => true,
+  },
+  {
+    id: ActionId.DisabledFull,
+    label: '모집 마감',
+    visibleIf: (c: FooterCtx) =>
+      c.role !== Role.host && c.current >= c.max && c.status === MeetingStatus.open,
+    variant: ButtonVariant.Outline,
+    handlerKey: 'onNoop',
+    disabled: () => true,
+  },
+  {
+    id: ActionId.Join,
+    label: '참여하기',
+    visibleIf: (c: FooterCtx) =>
+      c.role === Role.member &&
+      !c.isParticipated &&
+      c.current < c.max &&
+      c.status === MeetingStatus.open,
+    variant: ButtonVariant.Default,
+    handlerKey: 'onJoin',
+  },
+  {
+    id: ActionId.CancelJoin,
+    label: '참여취소',
+    visibleIf: (c: FooterCtx) =>
+      c.role === Role.member && c.isParticipated && c.status === MeetingStatus.open,
+    variant: ButtonVariant.Outline,
+    handlerKey: 'onCancelJoin',
+  },
+  {
+    id: ActionId.WriteReview,
+    label: '리뷰 작성하기',
+    visibleIf: (c: FooterCtx) =>
+      c.role === Role.member &&
+      c.isParticipated &&
+      c.status === MeetingStatus.closed &&
+      !c.isReviewed,
+    variant: ButtonVariant.Default,
+    handlerKey: 'onWriteReview',
+  },
+  {
+    id: ActionId.Share,
+    label: '공유하기',
+    visibleIf: (c: FooterCtx) =>
+      c.role !== Role.guest && c.status === MeetingStatus.closed && !!c.isReviewed,
+    variant: ButtonVariant.Outline,
+    handlerKey: 'onShare',
+  },
+  {
+    id: ActionId.CancelMeeting,
+    label: '모임 취소하기',
+    visibleIf: (c: FooterCtx) => c.role === Role.host && c.status === MeetingStatus.open,
+    variant: ButtonVariant.Outline,
+    handlerKey: 'onCancelMeeting',
+  },
+];

--- a/src/widgets/detail-meeting/model/getVisibleActions.ts
+++ b/src/widgets/detail-meeting/model/getVisibleActions.ts
@@ -1,0 +1,6 @@
+import { ACTIONS } from './actions';
+import type { FooterCtx, ActionDef } from './types';
+
+export function getVisibleActions(ctx: FooterCtx): ActionDef[] {
+  return ACTIONS.filter((a) => a.visibleIf(ctx));
+}

--- a/src/widgets/detail-meeting/model/hook/useConfirm.tsx
+++ b/src/widgets/detail-meeting/model/hook/useConfirm.tsx
@@ -1,0 +1,82 @@
+'use client';
+
+import { useCallback, useMemo, useRef, useState } from 'react';
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from '@/shared/ui';
+
+interface Options {
+  title?: string;
+  description?: string;
+  confirmText?: string;
+  cancelText?: string;
+  destructive?: boolean;
+}
+
+export function useConfirm() {
+  const [open, setOpen] = useState(false);
+  const optsRef = useRef<Options>({});
+  const resolverRef = useRef<((v: boolean) => void) | null>(null);
+
+  const confirm = useCallback((options?: Options) => {
+    optsRef.current = {
+      title: options?.title ?? '확인',
+      description: options?.description ?? '이 작업을 진행할까요?',
+      confirmText: options?.confirmText ?? '확인',
+      cancelText: options?.cancelText ?? '취소',
+      destructive: options?.destructive ?? false,
+    };
+    setOpen(true);
+    return new Promise<boolean>((resolve) => {
+      resolverRef.current = resolve;
+    });
+  }, []);
+
+  const handleClose = useCallback((result: boolean) => {
+    setOpen(false);
+    resolverRef.current?.(result);
+    resolverRef.current = null;
+  }, []);
+
+  const ConfirmDialog = useMemo(
+    () =>
+      function ConfirmDialogUI() {
+        const { title, description, confirmText, cancelText, destructive } = optsRef.current;
+        return (
+          <AlertDialog open={open} onOpenChange={(v) => !v && handleClose(false)}>
+            <AlertDialogContent>
+              <AlertDialogHeader>
+                <AlertDialogTitle>{title}</AlertDialogTitle>
+                <AlertDialogDescription>{description}</AlertDialogDescription>
+              </AlertDialogHeader>
+              <AlertDialogFooter>
+                <AlertDialogCancel onClick={() => handleClose(false)}>
+                  {cancelText}
+                </AlertDialogCancel>
+                <AlertDialogAction
+                  onClick={() => handleClose(true)}
+                  className={
+                    destructive
+                      ? 'border bg-background shadow-xs hover:bg-danger/20 dark:bg-input/30 dark:border-danger/60 dark:hover:bg-danger/30 border-danger text-danger'
+                      : 'text-muted'
+                  }
+                >
+                  {confirmText}
+                </AlertDialogAction>
+              </AlertDialogFooter>
+            </AlertDialogContent>
+          </AlertDialog>
+        );
+      },
+    [open, handleClose],
+  );
+
+  return { confirm, ConfirmDialog };
+}

--- a/src/widgets/detail-meeting/model/hook/useStickyFooter.tsx
+++ b/src/widgets/detail-meeting/model/hook/useStickyFooter.tsx
@@ -1,0 +1,36 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+
+export function useStickyFooter() {
+  const [isMobile, setIsMobile] = useState(false);
+  const [isFixed, setIsFixed] = useState(true);
+
+  useEffect(() => {
+    const mq = window.matchMedia('(max-width: 767px)');
+    const apply = () => setIsMobile(mq.matches);
+    apply();
+    const onMM = () => apply();
+    mq.addEventListener('change', onMM);
+
+    const onScroll = () => {
+      if (mq.matches) {
+        setIsFixed(false);
+        return;
+      }
+      const nearBottom =
+        window.scrollY + window.innerHeight >= document.documentElement.scrollHeight - 80;
+      setIsFixed(!nearBottom);
+    };
+
+    onScroll();
+    window.addEventListener('scroll', onScroll, { passive: true });
+
+    return () => {
+      mq.removeEventListener('change', onMM);
+      window.removeEventListener('scroll', onScroll);
+    };
+  }, []);
+
+  return { isMobile, isFixed };
+}

--- a/src/widgets/detail-meeting/model/types.ts
+++ b/src/widgets/detail-meeting/model/types.ts
@@ -1,3 +1,5 @@
+import { MeetingDetailInfo } from '@/entities/meetings/model/types';
+
 export interface WishButtonProps {
   isWished: boolean;
   meetingId: number;
@@ -7,4 +9,68 @@ export interface WishButtonProps {
 export interface ContentBoxProps {
   title: string;
   content: string;
+}
+
+export enum MeetingStatus {
+  open = 'open',
+  closed = 'closed',
+  cancelled = 'cancelled',
+}
+
+export enum Role {
+  guest = 'guest',
+  member = 'member',
+  host = 'host',
+}
+
+export enum ButtonVariant {
+  Default = 'default',
+  Outline = 'outline',
+}
+
+export enum ActionId {
+  Login = 'login',
+  Join = 'join',
+  CancelJoin = 'cancelJoin',
+  WriteReview = 'writeReview',
+  Share = 'share',
+  CancelMeeting = 'cancelMeeting',
+  DisabledFull = 'disabledFull',
+  DisabledClosed = 'disabledClosed',
+}
+
+export interface FooterCtx {
+  role: Role;
+  status: MeetingStatus;
+  current: number;
+  max: number;
+  fee: number;
+  isParticipated: boolean;
+  isReviewed?: boolean;
+}
+
+export interface Handlers {
+  onLogin: () => void;
+  onJoin: () => void;
+  onCancelJoin: () => void;
+  onWriteReview: () => void;
+  onShare: () => void;
+  onCancelMeeting: () => void;
+  onNoop?: () => void;
+}
+
+export interface ActionDef {
+  id: ActionId;
+  label: string;
+  visibleIf: (ctx: FooterCtx) => boolean;
+  disabled?: (ctx: FooterCtx) => boolean;
+  variant?: ButtonVariant;
+  handlerKey: keyof Handlers;
+}
+
+export interface MeetingFooterProps {
+  meeting: MeetingDetailInfo;
+  role?: Role;
+  isHost?: boolean;
+  handlers: Handlers;
 }

--- a/src/widgets/detail-meeting/ui/ActionButtons.tsx
+++ b/src/widgets/detail-meeting/ui/ActionButtons.tsx
@@ -8,11 +8,7 @@ export default function ActionButtons({ ctx, handlers }: { ctx: FooterCtx; handl
   const actions = getVisibleActions(ctx);
 
   if (actions.length === 0) {
-    return (
-      <Button variant="outline" disabled className="px-6 py-5 min-w-[120px] text-muted-foreground">
-        진행 불가
-      </Button>
-    );
+    return <Button variant="outlinePrimary">진행 불가</Button>;
   }
 
   const call = (key: keyof Handlers) => () => (handlers[key] ?? handlers.onNoop)?.();
@@ -21,17 +17,18 @@ export default function ActionButtons({ ctx, handlers }: { ctx: FooterCtx; handl
     <>
       {actions.map((a) => {
         const disabled = a.disabled?.(ctx) ?? false;
-        const variant = a.variant === ButtonVariant.Outline ? 'outline' : 'default';
+        const variant = a.variant === ButtonVariant.Outline ? 'outlinePrimary' : 'default';
         return (
-          <Button
-            key={a.id}
-            variant={variant}
-            disabled={disabled}
-            onClick={call(a.handlerKey)}
-            className={`px-6 py-5 min-w-[120px] ${disabled ? 'text-muted-foreground' : 'text-white'}`}
-          >
-            {a.label}
-          </Button>
+          <>
+            <Button key={a.id} variant={variant} disabled={disabled} onClick={call(a.handlerKey)}>
+              {a.label}
+            </Button>
+            {disabled && (
+              <Button key={`review-${a.id}`} variant="outlinePrimary">
+                리뷰 작성하기
+              </Button>
+            )}
+          </>
         );
       })}
     </>

--- a/src/widgets/detail-meeting/ui/ActionButtons.tsx
+++ b/src/widgets/detail-meeting/ui/ActionButtons.tsx
@@ -1,0 +1,39 @@
+'use client';
+
+import { Button } from '@/shared/ui';
+import { getVisibleActions } from '../model/getVisibleActions';
+import { FooterCtx, Handlers, ButtonVariant } from '../model/types';
+
+export default function ActionButtons({ ctx, handlers }: { ctx: FooterCtx; handlers: Handlers }) {
+  const actions = getVisibleActions(ctx);
+
+  if (actions.length === 0) {
+    return (
+      <Button variant="outline" disabled className="px-6 py-5 min-w-[120px] text-muted-foreground">
+        진행 불가
+      </Button>
+    );
+  }
+
+  const call = (key: keyof Handlers) => () => (handlers[key] ?? handlers.onNoop)?.();
+
+  return (
+    <>
+      {actions.map((a) => {
+        const disabled = a.disabled?.(ctx) ?? false;
+        const variant = a.variant === ButtonVariant.Outline ? 'outline' : 'default';
+        return (
+          <Button
+            key={a.id}
+            variant={variant}
+            disabled={disabled}
+            onClick={call(a.handlerKey)}
+            className={`px-6 py-5 min-w-[120px] ${disabled ? 'text-muted-foreground' : 'text-white'}`}
+          >
+            {a.label}
+          </Button>
+        );
+      })}
+    </>
+  );
+}

--- a/src/widgets/detail-meeting/ui/FooterText.tsx
+++ b/src/widgets/detail-meeting/ui/FooterText.tsx
@@ -1,0 +1,13 @@
+'use client';
+
+export default function FooterText({ fee }: { fee: number }) {
+  const text = fee === 0 ? '무료' : `${fee.toLocaleString()}원`;
+  return (
+    <div className="flex flex-col">
+      <span className="font-bold text-lg">참가비 : {text}</span>
+      <span className="text-xs text-muted-foreground">
+        모두 함께 To tasty! 한 모금으로 이어지는 나만의 취향 찾기
+      </span>
+    </div>
+  );
+}

--- a/src/widgets/detail-meeting/ui/ParticipantsText.tsx
+++ b/src/widgets/detail-meeting/ui/ParticipantsText.tsx
@@ -1,0 +1,17 @@
+'use client';
+
+export default function ParticipantsText({
+  current,
+  max,
+  className,
+}: {
+  current: number;
+  max: number;
+  className?: string;
+}) {
+  return (
+    <span className={`text-sm hidden sm:block mr-2 ${className ?? ''}`}>
+      {current}/{max}명 참여 중
+    </span>
+  );
+}

--- a/src/widgets/detail-meeting/ui/index.ts
+++ b/src/widgets/detail-meeting/ui/index.ts
@@ -1,2 +1,3 @@
 export { default as WithIcon } from './WithIcon';
 export { default as WishButton } from './WishButton';
+export { default as ActionButtons } from './ActionButtons';

--- a/src/widgets/detail-meeting/ui/index.ts
+++ b/src/widgets/detail-meeting/ui/index.ts
@@ -1,3 +1,5 @@
 export { default as WithIcon } from './WithIcon';
 export { default as WishButton } from './WishButton';
 export { default as ActionButtons } from './ActionButtons';
+export { default as FooterText } from './FooterText';
+export { default as ParticipantsText } from './ParticipantsText';


### PR DESCRIPTION
## 📑 연관 이슈
- close: #198 

## 🛠️ 작업 내용
- footer ui 구현
- 스크롤에 따른 stickyFooter 구현
- 상태 값에 따른 풋터 버튼 보이기

## 👀 리뷰 요청사항
- 
