### PR TITLE
Refactor/#210 tastinginfo 타입 위치 변경

### DIFF
--- a/src/entities/meetings/model/types.ts
+++ b/src/entities/meetings/model/types.ts
@@ -1,4 +1,4 @@
-import { DrinkType } from '@/shared';
+import { DrinkType, LocationInfo } from '@/shared';
 
 export enum SortType {
   latest = 'LATEST',
@@ -20,11 +20,7 @@ export interface MeetingCardInfo {
   meetingId: number;
   meetingAuthor: string;
   meetingTitle: string;
-  location: {
-    sido: string;
-    address: string;
-    detail: string;
-  };
+  location: LocationInfo;
   participationFee: number;
   startAt: string;
   joinEndAt: string;

--- a/src/entities/reviews/model/types.ts
+++ b/src/entities/reviews/model/types.ts
@@ -1,4 +1,4 @@
-import { TastingInfo } from '@/entities/tasting-list';
+import { TastingInfo } from '@/shared';
 
 interface ReviewContent {
   reviewId: number;

--- a/src/entities/tasting-list/index.ts
+++ b/src/entities/tasting-list/index.ts
@@ -1,2 +1,1 @@
 export { default as useTastingListQuery } from './model/hooks/useTastingListQuery';
-export type { TastingInfo } from './model/types';

--- a/src/entities/tasting-list/model/types.ts
+++ b/src/entities/tasting-list/model/types.ts
@@ -1,14 +1,4 @@
-import { DrinkType } from '@/shared';
-
-export interface TastingInfo {
-  drinkId?: number;
-  drinkName?: string;
-  drinkTaste?: string; // 음료 맛
-  drinkFlavor?: string; // 음료 향
-  drinkColor?: string; // 음료 색
-  drinkImgUrl?: string;
-  drinkType?: DrinkType;
-}
+import { TastingInfo } from '@/shared';
 
 export interface TastingList {
   tastingList: TastingInfo[];

--- a/src/features/meetings/model/types.ts
+++ b/src/features/meetings/model/types.ts
@@ -1,5 +1,4 @@
-import { TastingInfo } from '@/entities/tasting-list';
-import { LocationInfo } from '@/shared';
+import { LocationInfo, TastingInfo } from '@/shared';
 
 export interface PostMeetingRequest {
   meetingTitle: string;

--- a/src/features/meetings/model/types.ts
+++ b/src/features/meetings/model/types.ts
@@ -1,12 +1,9 @@
 import { TastingInfo } from '@/entities/tasting-list';
+import { LocationInfo } from '@/shared';
 
 export interface PostMeetingRequest {
   meetingTitle: string;
-  location: {
-    sido: string;
-    address: string;
-    detail: string;
-  };
+  location: LocationInfo;
   participationFee: number;
   startAt: string;
   joinEndAt: string;

--- a/src/features/reviews/model/types.ts
+++ b/src/features/reviews/model/types.ts
@@ -1,4 +1,4 @@
-import { TastingInfo } from '@/entities/tasting-list';
+import { TastingInfo } from '@/shared';
 
 export interface PostReviewInfo {
   meetingId: number;

--- a/src/shared/constants/index.ts
+++ b/src/shared/constants/index.ts
@@ -1,1 +1,1 @@
-export { DrinkType } from './types';
+export * from './types';

--- a/src/shared/constants/types.ts
+++ b/src/shared/constants/types.ts
@@ -10,3 +10,13 @@ export interface LocationInfo {
   address: string;
   detail: string;
 }
+
+export interface TastingInfo {
+  drinkId?: number;
+  drinkName?: string;
+  drinkTaste?: string; // 음료 맛
+  drinkFlavor?: string; // 음료 향
+  drinkColor?: string; // 음료 색
+  drinkImgUrl?: string;
+  drinkType?: DrinkType;
+}

--- a/src/shared/constants/types.ts
+++ b/src/shared/constants/types.ts
@@ -4,3 +4,9 @@ export enum DrinkType {
   wine = 'WINE',
   end = 'END',
 }
+
+export interface LocationInfo {
+  sido: string;
+  address: string;
+  detail: string;
+}

--- a/src/shared/lib/form/model/types.ts
+++ b/src/shared/lib/form/model/types.ts
@@ -75,9 +75,3 @@ export interface UseFieldValueOptions {
     | 'RatingField';
   fieldName?: string;
 }
-
-export interface LocationInfo {
-  sido: string;
-  address: string;
-  detail: string;
-}

--- a/src/shared/lib/index.ts
+++ b/src/shared/lib/index.ts
@@ -1,4 +1,3 @@
 export { default as useGlobalErrorStore } from './error/useGlobalErrorStore';
 export { default as useAppForm } from './form/model/hooks/useAppForm';
 export { default as compressImage } from './compressImage';
-export type { LocationInfo } from './form/model/types';

--- a/src/shared/ui/form/AddressField.tsx
+++ b/src/shared/ui/form/AddressField.tsx
@@ -4,7 +4,8 @@ import { useState } from 'react';
 import DaumPostcode, { Address } from 'react-daum-postcode';
 import useFieldValue from '../../lib/form/model/hooks/useFieldValue';
 import FormField from './FormField';
-import { LocationInfo, AddressFieldProps } from '../../lib/form/model/types';
+import { LocationInfo } from '../../constants';
+import { AddressFieldProps } from '../../lib/form/model/types';
 import { Button, Input, Popover, PopoverContent, PopoverTrigger } from '../index';
 
 export default function AddressField({

--- a/src/widgets/post-meeting/model/postMeetingOptions.ts
+++ b/src/widgets/post-meeting/model/postMeetingOptions.ts
@@ -1,6 +1,5 @@
 import { formOptions } from '@tanstack/react-form';
-import { TastingInfo } from '@/entities/tasting-list';
-import { DrinkType, LocationInfo } from '@/shared';
+import { DrinkType, LocationInfo, TastingInfo } from '@/shared';
 import PostMeetingFormData from './types';
 
 const defaultValues: PostMeetingFormData = {

--- a/src/widgets/post-meeting/model/types.ts
+++ b/src/widgets/post-meeting/model/types.ts
@@ -1,13 +1,9 @@
-import { DrinkType } from '@/shared';
+import { DrinkType, LocationInfo } from '@/shared';
 import { TastingInfo } from '@/entities/tasting-list';
 
 export default interface PostMeetingFormData {
   meetingTitle: string;
-  location: {
-    sido: string;
-    address: string;
-    detail: string;
-  };
+  location: LocationInfo;
   participationFee: number;
   startAt: string;
   joinEndAt: string;

--- a/src/widgets/post-meeting/model/types.ts
+++ b/src/widgets/post-meeting/model/types.ts
@@ -1,5 +1,4 @@
-import { DrinkType, LocationInfo } from '@/shared';
-import { TastingInfo } from '@/entities/tasting-list';
+import { DrinkType, LocationInfo, TastingInfo } from '@/shared';
 
 export default interface PostMeetingFormData {
   meetingTitle: string;

--- a/src/widgets/reviews/post/model/types.ts
+++ b/src/widgets/reviews/post/model/types.ts
@@ -1,5 +1,4 @@
-// TastingInfo
-import { TastingInfo } from '@/entities/tasting-list';
+import { TastingInfo } from '@/shared';
 
 export default interface ReviewFormData {
   meetingId: number;

--- a/src/widgets/reviews/post/ui/ReviewImgCard.tsx
+++ b/src/widgets/reviews/post/ui/ReviewImgCard.tsx
@@ -1,5 +1,5 @@
 import Image from 'next/image';
-import { TastingInfo } from '@/entities/tasting-list';
+import { TastingInfo } from '@/shared';
 
 interface ReviewImgProps {
   item: TastingInfo;


### PR DESCRIPTION
## 📑 연관 이슈
- close: #210 

## 🛠️ 작업 내용
- `LocationInfo` 및 `TastingInfo`  위치 constants/types.ts 로 이동

## 👀 리뷰 요청사항
- 인터페이스 선언 위치 변경 되었습니다.
  사용하시는 타입들에서 변경될 부분있는지 확인부탁드려용~
